### PR TITLE
Env var hint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ use args::OxdArgs;
 use clap::Parser;
 
 fn main() {
+    let args = OxdArgs::parse();
+
     let app_id = env::var("OD_API_APP_ID").unwrap_or_else(|err| {
         eprintln!("Problem reading Oxford Dictionary API App ID: {err}\nGet one at https://developer.oxforddictionaries.com/ and set OD_API_APP_ID.");
         process::exit(1);
@@ -17,7 +19,6 @@ fn main() {
         process::exit(1);
     });
 
-    let args = OxdArgs::parse();
     let client = build_client(app_id, app_key);
 
     if let Some(retrieve_entry) = get_entry(&client, &args.word) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,11 @@ use clap::Parser;
 
 fn main() {
     let app_id = env::var("OD_API_APP_ID").unwrap_or_else(|err| {
-        println!("Problem reading Oxford Dictionary API App ID: {err}");
+        eprintln!("Problem reading Oxford Dictionary API App ID: {err}\nGet one at https://developer.oxforddictionaries.com/ and set OD_API_APP_ID.");
         process::exit(1);
     });
     let app_key = env::var("OD_API_APP_KEY").unwrap_or_else(|err| {
-        println!("Problem reading Oxford Dictionary API App KEY: {err}");
+        eprintln!("Problem reading Oxford Dictionary API App KEY: {err}\nGet one at https://developer.oxforddictionaries.com/ and set OD_API_APP_KEY.");
         process::exit(1);
     });
 


### PR DESCRIPTION
## Before

Even `oxd --help` will fail if the environmental variables are missing. Moreover, the error message doesn't tell what is missing or how to fix that.

```shell
$ oxd --help
Problem reading Oxford Dictionary API App KEY: environment variable not found
```

## After

- `oxd --help` works all the time.
- ```shell
  $ oxd rust  # without env variables
  Problem reading Oxford Dictionary API App KEY: environment variable not found
  Get one at https://developer.oxforddictionaries.com/ and set OD_API_APP_KEY.
  ```