### PR TITLE
feature: Etymologies / origins

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -29,7 +29,7 @@ impl Display for RetrieveEntry {
 
 impl Display for HeadwordEntry {
     fn display(&self, output: &mut String) {
-        write!(output, "{}  ", self.word).unwrap();
+        write!(output, "{}  ", self.word.bold().underline()).unwrap();
         if has_consistent_pronunciation(&self) {
             // Assume "at least one `LexicalEntry`" and "must only one `Entry`"
             self.lexical_entries[0].entries[0]
@@ -37,19 +37,33 @@ impl Display for HeadwordEntry {
                 .display(output);
         }
         writeln!(output).unwrap();
+
         self.lexical_entries.display(output);
+        writeln!(output).unwrap();
+
+        self.origins().iter().for_each(|origin| {
+            write!(output, "[{}]  ", "origin".magenta()).unwrap();
+            origin.display(output);
+        });
         writeln!(output).unwrap();
     }
     fn to_html(&self, output: &mut String) {
-        write!(output, "<p>{}  ", self.word).unwrap();
+        write!(output, "<p><u><b>{}</b></u>  ", self.word).unwrap();
         if has_consistent_pronunciation(&self) {
             // Assume "at least one `LexicalEntry`" and "must only one `Entry`"
             self.lexical_entries[0].entries[0]
                 .pronunciations
                 .to_html(output);
         }
+
         write!(output, "</p>").unwrap();
         self.lexical_entries.to_html(output);
+
+        self.origins().iter().for_each(|origin| {
+            write!(output, "<p>[origin]  ").unwrap();
+            origin.to_html(output);
+        });
+        write!(output, "</p>").unwrap();
     }
 }
 
@@ -58,7 +72,12 @@ impl Display for LexicalEntry {
         if is_empty_entries(&self.entries) {
             return;
         }
-        write!(output, "\n{}  ", self.lexical_category.id.italic()).unwrap();
+        write!(
+            output,
+            "\n{}  ",
+            self.lexical_category.id.italic().magenta()
+        )
+        .unwrap();
         self.derivative_of.display(output);
         self.entries.display(output);
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,7 +2,7 @@
  * Struct hierarchy:
  * - [_Sense_](Sense) { [_domains_](Domain), [_registers_](Register), _definitions_, _cross_reference_markers_, [_examples_](Example), [_subsenses_](Sense) }
  * -   ^
- * - [Entry] { [_pronunciations_](Pronunciation), [_variant_forms_](VariantForm) }
+ * - [Entry] { [_pronunciations_](Pronunciation), [_variant_forms_](VariantForm), _origins_ }
  * -   ^
  * - [LexicalEntry] { text, language, [lexical_category](LexicalCategory), [_derivative_of_](DerivativeOf) }
  * -   ^
@@ -41,6 +41,8 @@ pub struct Entry {
     pub pronunciations: Option<Vec<Pronunciation>>,
     #[serde(rename = "variantForms")]
     pub variant_forms: Option<Vec<VariantForm>>,
+    #[serde(rename = "etymologies")]
+    pub origins: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -194,4 +196,19 @@ pub fn roots(retrieve_entry: &RetrieveEntry) -> Vec<DerivativeOf> {
         }
     }
     roots
+}
+
+impl HeadwordEntry {
+    pub fn origins<'a>(&'a self) -> Vec<&'a String> {
+        self.lexical_entries
+            .iter()
+            .flat_map(|lexical_entry| {
+                lexical_entry
+                    .entries
+                    .iter()
+                    .filter_map(|e| e.origins.as_ref())
+                    .flatten()
+            })
+            .collect()
+    }
 }


### PR DESCRIPTION
- Add a **new section**: origin.

  ```shell
  $ oxd etymology
  …
  [origin]  late Middle English: from Old French ethimologie, via Latin from Greek etumologia, …
  ```

- **Style changes**

  - headword: plain → **bold** + <u>underline</u>.
  - sections and lexical categories: plain/italic → plain/italic + magenta.

  The new style looks better for queries that return multiple results. (Learned from [oxdi](https://github.com/knightpp/oxdi))

![](https://user-images.githubusercontent.com/73375426/216028903-b2cbdb85-d1f6-49d5-adf9-718af7ffbdbd.png)

## API

`/words` API returns etymologies in entries: (in [JSONPath](https://github.com/JSONPath-Plus/JSONPath))

```javascript
$.results[*].lexicalEntries[*].entries[0].etymologies.*
```

## [Wiki](https://github.com/chunjiw/oxd/wiki) updates

### Limitation / assumptions

- Each result (`HeadwordEntry`) has exactly **one origin**.

  I print the origin after all lexical entries.

- I ignore **sense level etymologies**, a feature added in [v2.1 (23 July 2019)](https://developer.oxforddictionaries.com/updates) and [documented](https://developer.oxforddictionaries.com/documentation) in current API.

  ```javascript
  $.results[*].lexicalEntries[*].entries[0].senses[*].etymologies.*
                                              👆
  ```

  I cannot find any sense level etymologies in practice. [Multi-origin](https://english.stackexchange.com/questions/536594/is-there-a-terminology-for-one-word-multiple-distinct-etymologies) words do exist, but they are reported in result level.

### Examples of entries

| Weirdness                                 | Word(s)             |
| :---------------------------------------- | :------------------ |
| multiple headwords (with one origin each) | bass, minute        |
| missing origin                            | Antarctica, oxidize |
| special characters in origins (e.g. ǣ)    | least, oxide        |

